### PR TITLE
Fix postgres default password && allow postgres to start before running rake in setup.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
   web:
     build: .
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,9 @@ docker-compose run web rails new . --force --no-deps --database=postgresql
 docker-compose build
 cp new_database_config.yml config/database.yml
 rm new_database_config.yml
-docker-compose run web rake db:create
+docker-compose up -d
 
+sleep 15
+
+docker-compose run web rake db:create
 


### PR DESCRIPTION
The postgres image will complain unless a password is set or passwordless auth is enabled. This change enables passwordless auth, and also allows postgres to start up before trying to run rake migrate on it.